### PR TITLE
Sync docs with analyzer behavior + early-error-return fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ When a false positive is identified, follow this cycle **exactly**. Do NOT skip 
 - `lib/Inst.zig` - Inst struct and results list management only
 - `lib/dump.zig` - Debug formatting (uses accessor functions from analysis modules)
 
-Analyte manipulation (`.analyte.undefined_safety`, `.analyte.memory_safety`, `.analyte.null_safety`, `.analyte.variant_safety`, `.analyte.fieldparentptr_safety`) is the EXCLUSIVE responsibility of analysis modules in `lib/analysis/`.
+Analyte manipulation (`.analyte.undefined_safety`, `.analyte.memory_safety`, `.analyte.null_safety`, `.analyte.variant_safety`, `.analyte.fieldparentptr_safety`, `.analyte.fd_safety`) is the EXCLUSIVE responsibility of analysis modules in `lib/analysis/`.
 
 Tag handlers should only:
 1. Set up refinement STRUCTURE (pointer, scalar, struct, etc.) via `appendEntity`
@@ -415,10 +415,14 @@ test "instLine for my_new_tag" {
     var arena = clr_allocator.newArena();
     defer arena.deinit();
 
-    const datum: Data = .{ /* appropriate data for this tag */ };
-    const result = codegen._instLine(arena.allocator(), dummy_ip, .my_new_tag, datum, 0, &.{}, &.{}, &.{}, &.{}, null);
+    // FnInfo bundles the arena, ip, tags, and other per-function context.
+    var info: FnInfo = .{ /* ...set up arena, ip, etc... */ };
 
-    try std.testing.expectEqualStrings("    try Inst.apply(0, .{ .my_new_tag = .{ /* expected payload */ } }, results, ctx, &refinements);\n", result);
+    const datum: Data = .{ /* appropriate data for this tag */ };
+    // Signature: _instLine(info: *const FnInfo, tag, datum, inst_index, arg_counter)
+    const result = codegen._instLine(&info, .my_new_tag, datum, 0, null);
+
+    try std.testing.expectEqualStrings("    try Inst.apply(state, 0, .{ .my_new_tag = .{ /* expected payload */ } });\n", result);
 }
 ```
 
@@ -463,9 +467,11 @@ Tags are defined inline in `lib/tag.zig`. Add a new struct type and include it i
 pub const MyNewTag = struct {
     field: u32,  // fields matching the payload
 
-    pub fn apply(self: @This(), results: []Inst, index: usize, ctx: *Context, refinements: *Refinements) !void {
-        // Tag-specific logic (if any) before analysis dispatch
-        try splat(.my_new_tag, results, index, ctx, refinements, self);
+    // `state: State` bundles results, refinements, and ctx.
+    pub fn apply(self: @This(), state: State, index: usize) !void {
+        // Set up refinement STRUCTURE here (via state.refinements), then
+        // dispatch to analysis modules:
+        try splat(.my_new_tag, state, index, self);
     }
 };
 
@@ -481,7 +487,11 @@ If the tag affects an analysis (e.g., undefined tracking), add a handler:
 
 ```zig
 // In lib/analysis/undefined_safety.zig (or other analysis module)
-pub fn my_new_tag(results: []Inst, index: usize, ctx: *Context, refinements: *Refinements, payload: anytype) !void {
+// First arg is `state: State`; the last arg is the concrete tag struct
+// (e.g. `tag.MyNewTag`), not a generic `anytype`.
+pub fn my_new_tag(state: State, index: usize, params: tag.MyNewTag) !void {
+    const results = state.results;
+    const refinements = state.refinements;
     // Analysis logic - update results, report errors, etc.
 }
 ```
@@ -623,16 +633,9 @@ We won't prevent failures due to union tag field being set to an invalid value. 
 
 ### Setting a pointer to undefined
 
-Need to investigate what happens when a pointer itself is set to undefined (e.g., `var ptr: *u8 = undefined;`). Currently we set `pointer.analyte.undefined = undef_state`, but this needs testing and verification.
+Need to investigate what happens when a pointer itself is set to undefined (e.g., `var ptr: *u8 = undefined;`). Currently we set the pointer's own `analyte.undefined_safety` state while `pointer.to` still points at its (potentially undefined) pointee, but this needs testing and verification.
 
-We may need to make `pointer.to` an optional value - an undefined pointer doesn't point to anything valid.
-
-### Simple tags need BinOp/UnOp refinement
-
-The `Simple` type currently just produces a scalar without tracking operands. For proper data flow analysis, we'll need to:
-- Split into `BinOp` (binary operations like `bit_and`, `cmp_*`, `sub`) and `UnOp` (unary operations like `ctz`)
-- Pass operand parameters to track where values flow from
-- Currently affects: `bit_and`, `cmp_eq`, `cmp_gt`, `cmp_lte`, `ctz`, `sub`
+Note: `pointer.to` is a required `Gid`, not optional. An undefined pointer still has a `.to` target entity; the undefined-ness is tracked on the pointer's `undefined_safety` analyte rather than by nulling `.to`.
 
 ### Runtime union tag comparisons not tracked
 
@@ -647,17 +650,16 @@ if (my_union == some_tag) {  // NOT recognized - some_tag is runtime value
 
 This is an intentional limitation - tracking runtime tag values would require complex value flow analysis.
 
-### `dbg_inline_block` not implemented
-
-The `dbg_inline_block` instruction is used for inlined function calls. This needs investigation to understand how it affects data flow tracking - inlined code may need special handling to maintain correct interprocedural analysis.
-
 ### Other return instructions not implemented
 
-Only `ret_safe` is implemented. The following return variants are marked as `Unimplemented` and need proper handling:
+`ret_safe`, `ret_ptr`, and `ret_load` are implemented. `ret_ptr` creates a
+pointer to a local entity used to build up the return value, and `ret_load`
+copies that built-up value to the return slot (used for large return values
+that don't fit in registers).
 
-- **`ret_addr`**: Returns the return address (used for stack traces). Probably safe to leave as unimplemented since it's metadata, not data flow.
-- **`ret_load`**: Returns by loading from a pointer (used for large return values that don't fit in registers). **TODO**: This affects data flow and needs implementation.
-- **`ret_ptr`**: Returns the pointer where the return value should be stored (caller provides storage). **TODO**: This affects data flow and needs implementation.
+- **`ret_addr`**: Returns the return address (used for stack traces). Still
+  produces `.unimplemented`. Probably safe to leave as unimplemented since it's
+  metadata, not data flow.
 
 ### `std.crypto.random` causes false positives
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,24 +1,29 @@
 # CLR Limitations
 
 This document tracks known limits in CLR's analyzer model. It should describe
-current behavior, not aspirational architecture. Use `AGENTS.md` for the active
-sprint baseline and `FIXES_LOG.md` for completed fixes.
+current behavior, and only mention aspirational architecture in passing.
 
 ## Stdlib overrides
 
 These are cases where stdlib code would look erroneous to CLR without
-stdlib-specific invariant facts. Usually, they are guarded by invariant
-conditions that can't be tracked simply by CLR, for example a size check
-guaranteeing nonnullability of an optional. In the case of user code that looked
-like this you would use a declaration (see below) to override the CLR issue.
+instrumented invariant facts.  In the case of user code that looked
+like this you would use a declaration (unimplemented; see below) to 
+override the CLR issue.  Stdlib is considered privileged and integral
+part of the zig language.  For example, use of the allocator interface 
+is considered required for memory safety tracking, and allocations
+not using the stdlib (for example, with syscalls) are considered to
+be untracked by CLR; idiomatic zig code SHOULD use the stdlib, so 
+CLR should be considered a tool to push users to build idiomatic and
+safe zig code.
 
 Topics in this section should not necessarily be considered missing features
-in CLR but rather informational content relating to the limitations of CLR.
+in CLR but rather informational content relating to how CLR overcomes
+analysis challenges for core operations.
 
 ### Allocators and fd operations
 
 CLR explicitly overrides stdlib's allocator and file descriptor functions as
-part of its expected normal operation. Mutexes may be added to this list in
+part of its expected core safety operations. Mutexes may be added to this list in
 the future.
 
 ### Stdlib HashMap Invariants
@@ -40,9 +45,9 @@ entries with independently managed pointer values may require multiple-source
 provenance or per-entry identities and is not yet claimed as fully modeled.
 Unlisted HashMap methods are unsupported until given focused boundary tests.
 
-This is a stdlib-specific override. User code should eventually express similar
-facts through a declarative refinement/tag mechanism rather than hidden
-HashMap-specific rules.
+This is a stdlib-specific override. User datastructures could eventually allow 
+similar analysis of user datas through a declarative refinement/tag mechanism 
+rather than hidden rules.
 
 ### Stdlib Byte Reinterpretation
 
@@ -53,125 +58,41 @@ intended. CLR models `std.mem.asBytes` with a narrow stdlib override that create
 a raw-byte pointer view over the same underlying memory, without changing the
 underlying object's multiplicity.
 
-### Process Argument Boundaries
+### Process Arguments
 
 `std.process.args` and its `ArgIterator` helpers are treated as an opaque stdlib
 boundary. CLR does not model the iterator's internal stdlib layout. Instead, the
-args/init path produces an opaque scalar marked `.interned`, and iterator
-operations such as `skip` and `next` only require the compiler-lowered self
-argument to exist.
-
-This relies on Zig's own type system and member-call lowering. User code cannot
-pass an arbitrary unrelated scalar as the first `self` parameter to
-`ArgIterator.next` in well-typed Zig; the AIR call shape has already passed the
-compiler's type checks before CLR sees it. Because of that, CLR does not add a
-custom runtime memory-safety tag just to distinguish the iterator handle. The
-handle is opaque to CLR and non-user-managed, which is exactly what `.interned`
-already means for this analysis.
-
-Argument strings returned by `next` are process-owned runtime memory. CLR models
-that returned string memory as `.interned`: not literally compile-time interned,
-but non-user-managed and not valid to free or destroy. Environment-variable
-iteration should use the same model when support is added.
-
-This intentionally does not prove safety for user-constructed values that happen
-to have the same shape as the stdlib iterator outside the compiler-typed
-`std.process` API surface. The override is a narrow stdlib boundary, not a
-general structural proof of `ArgIterator` layout.
+args/init path produces an opaque scalar marked `.interned` (this is strictly 
+not true, but it is a reasonable elision), and iterator operations such as `skip` 
+and `next` only require the compiler-lowered self argument to exist.
 
 ## Current Active Gaps (planned to be addressed)
 
 ### Declarations
 
-In the future, we will be implementing a "declarative statement" that
+In the future, we may implement a "declarative statement" that
 sets the CLR-tracked state of a variable. These declarations should let user
 code express facts such as preconditions, postconditions, and local refinement
-assertions that CLR cannot infer from ordinary AIR alone.
+assertions that CLR cannot infer from ordinary AIR alone.  Currently the 
+mechanism for these statements is decided, but the scope or shape of these 
+declarations has not been decided.
 
-### File Descriptor Alias And Closure Propagation
+### Custodial Relationships
 
-FD state is tracked for the covered stdlib/POSIX open, close, read/write,
-flock, dup, socket, accept, epoll, and pipe patterns. Basic propagation through
-stores, aggregate initialization, returned values, and scalar fields is covered
-by the current integration suite.
+CLR does not yet fully model *custody* — a container taking ownership of
+independently allocated values on behalf of the code that inserts them. The
+representative case is the stdlib HashMap: its refinement carries a single
+representative key slot and value slot, not per-entry storage. This covers
+scalar maps and the tested case where a stored aggregate owns one pointer
+allocation, but a map holding multiple entries with independently managed
+pointer values has no per-entry provenance or ownership identity, so their
+allocation lifecycles are not individually tracked.
 
-The remaining architecture work is descriptor aliasing and closure propagation.
-The broader model is still not a general descriptor alias analysis: copies or
-transformations that lose the tracked scalar FD refinement can also lose
-close/use/leak state, and raw syscalls or custom wrappers are only checked when
-they lower through a recognized override.
-
-Conditional closure of a non-optional descriptor is intentionally not a
-supported lifecycle pattern. Branch-local FD state can represent mutually
-exclusive exits such as a deferred close on success and error paths, but merging
-an open descriptor from one continuing branch with a closed descriptor from
-another leaves ambiguous post-branch state. Represent conditional descriptor
-ownership with an optional, close the unwrapped value, and clear or leave the
-optional according to the surrounding lifecycle. CLR's intended policy is to
-reject the ambiguous non-optional pattern rather than silently treat it as open
-or closed.
-
-### Stack Escape And Returned Aggregate Provenance
-
-Returning pointers inside structs, unions, or globals is still conservative in
-some cases. Basic fieldParentPtr recovery for structs, unions, and global
-struct/union fields is covered, but returned pointers through aggregate values
-and merged pointers can still lose enough provenance to produce false positives.
-
-Early error returns are handled: when a function takes an error path before its
-success payload is constructed, the interned error union's structural payload is
-marked an inactive error stub, so branch merging does not misreport the
-not-yet-allocated success payload (for example a slice field) as a leak.
-
-This area overlaps with stack lifetime tracking: CLR detects some escaping stack
-pointers, but it does not yet have a complete tombstone model for stack memory
-after function return.
-
-### Alignment-Cast Lowering
-
-`@ptrCast(@alignCast(...))` lowers into AIR that bitcasts a pointer to an
-address-like scalar, masks low bits, and branches on the alignment check. Current
-analyses can misinterpret that sequence as ordinary pointer/int dataflow.
-
-Planned mitigation: add an AIR-to-analyzer interceptor that recognizes this
-compiler-generated alignment guard and no-ops the failure branch for current
-analyses. A future `alignment_safety` module can track the actual alignment
-proof separately.
-
-### Pointer Arithmetic And Retagging
-
-`ptr_add` and `ptr_sub` both produce derived pointers into the same region.
-Neither operation proves that the pointer has returned to the allocation base.
-Freeing memory through a derived pointer should remain invalid unless a future
-explicit retag feature, or a narrow internal stdlib override, reestablishes
-base-allocation provenance.
-
-Pointer arithmetic must operate on a pointer-to-region. Non-pointer inputs and
-single-item pointer inputs should fail loudly with a clear analysis error.
-
-CLR does not perform pointer arithmetic bounds checking. It does not prove that
-the derived pointer remains within the region.
-
-## Memory And Provenance Model Limits
-
-### No Rust-Style Ownership Transfer
-
-CLR tracks provenance and safety, not exclusive ownership. More than one value
-or path may refer to the same allocation root GID. Once any path marks that root
-freed, the allocation's state collapses around that GID and later checks should
-use the collapsed state.
-
-Consequences:
-
-- allocation root GID is the allocation identity;
-- `allocator_gid` is only for allocator mismatch detection;
-- pointer values should point at already-existing GIDs in their destination
-  `Refinements` table;
-- cross-table operations may merge/import structure, but should not transfer a
-  pointer value's `.to` target across tables.
-
-Aliasing safety is separate from allocation memory safety and is not fully
-implemented yet.
+The same limitation applies in principle to any container that takes custody of
+distinct owned allocations. A full model needs per-entry (or multiple-source)
+provenance so that inserting, retrieving, and destroying individual owned values
+can be checked against the correct allocation root. This overlaps with the
+multiple-source pointer gap below.
 
 ### Multiple-Source Pointers
 
@@ -195,131 +116,46 @@ imprecise around merged pointer values: it may reject legal scalar/recursive
 updates, or it may require narrower special-case handling to avoid applying an
 unsafe destructive operation to an ambiguous source.
 
-### Interprocedural Allocation Safety
+### Aliasing safety
 
-CLR has limited call-boundary propagation and several common allocation-return
-and callee-free cases are covered. It still does not perform full
-interprocedural analysis with function summaries, call graph ordering, and
-context-sensitive value tracking.
+A strategy for aliasing safety is under consideration and the model for it
+is currently being designed.
 
-This means some patterns involving allocations returned through complex
-aggregates, stored in globals, or modified by callees can still be conservative
-or incomplete.
+### Allocator-wide deinit invalidation
 
-### Global Allocation Leak Detection
+When an allocator's backing datastructure (we'll call it "allocator" in this
+section) has its `deinit` called and frees all of its outstanding allocations at
+once, every allocation made through that allocator should become invalid, and
+later use of any of them should be reported as use-after-deinit. CLR currently
+models this only for `ArenaAllocator`: deinitializing the arena marks its
+allocations invalidated and detects use-after-deinit and double-deinit against
+them.
 
-Allocations reachable from globals are exempt from normal leak detection outside
-the entrypoint. At the entrypoint, CLR also checks allocations stored through
-global entities before program exit.
+The same lifecycle applies to other allocators whose `deinit` invalidates
+outstanding memory (for example `GeneralPurposeAllocator`, or a user allocator
+with the same contract). These are not yet given the arena treatment, so
+use-after-deinit through a non-arena allocator is not currently caught. The gap
+is generalizing the arena-specific deinit-invalidation model to any allocator
+that owns and releases its allocations on `deinit`.
 
-This avoids false positives for intentionally program-lifetime allocations inside
-library-style functions, but it also means memory allocated into a global from a
-non-entrypoint function and never freed may not be reported there as a leak.
+Nested allocators — an allocator whose memory comes from another allocator —
+fall out of the same generalization and still need targeted coverage.
 
-### Cross-Function Global Mutation
+### `intcast`
 
-Mutations to globals are tracked within a function, but a caller's view of a
-global is not generally updated after a callee mutates it.
+`intcast` is not implemented yet.
 
-Supporting this well likely requires inter-function dependency analysis or
-callee summaries for global side effects.
+### Pointer transforms on interned memory
 
-### Global Pointer Values
+`ptr_add`, `ptr_sub`, `array_to_slice`, and element-pointer construction do not
+currently work on `.interned` memory.
 
-Direct global addresses such as `&global_value` are handled better than pointer
-values loaded from global pointer variables. A loaded global pointer can lose the
-fact that its value points to global memory.
+### `.recursive` type placeholder
 
-Future work should preserve pointer-valued global initializer facts from the
-InternPool and import them when the global pointer value is loaded.
-
-### Nested Arena Allocators
-
-Arena-style memory management is mostly tracked, including init, deinit,
-allocator retrieval, leak detection, use-after-deinit, double-deinit, and
-cross-allocator mismatch detection. Nested arenas, where an arena is backed by
-another arena, remain less certain and need targeted tests before being treated
-as covered.
-
-## Variant, Optional, And Aggregate Limits
-
-### Global Union Initial Values
-
-Basic global union initial active variants are imported from the generated
-global refinement structure and are covered for the current integration suite.
-
-This area is still sensitive to InternPool shape. If a global union initializer
-cannot be represented as a `GlobalDef.union_field` with an active field entity,
-CLR may lose the initial active variant and later checked field access can be
-conservative or incomplete.
-
-Future work should keep adding targeted global-union initializer shapes as they
-appear in real AIR.
-
-### Optional Pointer AIR Semantics
-
-AIR instructions such as `is_non_null`, `is_null`, and `optional_payload` can
-appear around optional wrappers and pointer-like values. CLR's null-safety model
-should continue to distinguish optional state from raw pointer value state.
-
-Open questions:
-
-1. When does Zig emit these instructions for pointer values rather than
-   optionals?
-2. Which generated pointer checks should be modeled by null safety, and which
-   should be ignored or handled by another module?
-3. How should alignment or sentinel checks that look optional-like in AIR be
-   separated from actual optional unwraps?
-
-## AIR And Codegen Limits
-
-### Partially Implemented AIR Tags
-
-Some AIR instruction tags are handled only enough to avoid crashing and may
-produce `.unimplemented` refinements:
-
-- `intcast`
-- `ret_addr`
-- `stack_trace_frames`
-
-The return-address and stack-trace tags are unlikely to affect ordinary safety
-cases.
-`intcast` is more significant: it currently does not inherit undefined or other
-value safety state from its operand, so safety state can be lost across integer
-casts until that handler is completed.
-
-### Interned Operands In Pointer Transforms
-
-Several pointer-shape operations currently require an instruction-backed source.
-`ptr_add`, `ptr_sub`, `array_to_slice`, and element-pointer construction can
-panic when codegen supplies an interned source instead. Undefined-safety
-optional-payload handling also rejects a general interned optional source.
-
-Known stdlib boundaries and string/slice literals have narrower handling where
-needed by current coverage, but that does not make arbitrary interned globals or
-comptime pointer values valid inputs to these operations. Codegen should either
-resolve tracked globals before emitting the operation or preserve enough type
-and provenance information for runtime handling.
-
-### Codegen Type Extraction Gaps
-
-Some generated analyzer tags depend on extracting precise type information from
-AIR and the InternPool. When type extraction fails, CLR should prefer a loud
-`.unimplemented` refinement or analysis failure over guessing a scalar shape.
-
-Known examples include allocator `create` payload type extraction and slice
-element type reconstruction. These are correctness boundaries in the AIR-to-CLR
-translation layer rather than intentional safety allowances.
-
-Generated type descriptions inline aggregate structure. Repeated scalar-only
-struct types are expanded independently, including stdlib timestamp structures
-used by `std.fs.File.stat`. More complex repeated aggregates still use
-`.recursive` placeholders to bound generated output. The placeholder was
-designed for active recursive back-edges, but codegen also uses it for completed
-complex sibling types because the runtime type model has no reusable type
-definition reference. Operations that require such a sibling's full field shape
-may therefore fail analysis. General support requires a runtime type-reference
-representation rather than unrestricted structural expansion.
+The `.recursive` type placeholder is not fully implemented. It bounds generated
+type descriptions, but codegen emits it both for genuine recursive back-edges and
+for already-expanded sibling aggregates, and operations that need the full field
+shape of a `.recursive`-collapsed type can fail analysis.
 
 ### Indirect Function Calls
 
@@ -332,14 +168,87 @@ calls can dispatch through known targets with merged results. Limitations remain
 - merging multiple possible targets can produce false positives when only one
   target is feasible at runtime.
 
+### Call-stack metadata (`ret_addr`, `stack_trace_frames`)
+
+These produce call-stack metadata rather than program data and are currently
+unimplemented. That is harmless as long as nothing consumes the result,
+but stack-trace-reporting code that reads `@returnAddress()` or walks a
+`StackTrace`'s frames will crash the analyzer (these are generally rare,
+most programs rely on zig's default stacktrace handling).
+
+### Flagging unsafe code
+
+CLR cannot prove every construct safe, and some operations are inherently
+unsafe or unmodeled (for example `ptr_add` and other pointer arithmetic). Rather
+than silently pass or hard-error on these, CLR should recognize such patterns and
+emit a list of source locations that warrant manual review — a "please check
+these" report rather than a proof obligation. This surfacing mechanism is not yet
+implemented.
+
+## Memory Safety And Provenance Model (not Rust's)
+
+CLR does track memory safety, but it does not use Rust's ownership model to do
+it. The distinction matters for understanding what CLR proves and what it does
+not.
+
+Rust enforces safety by ownership: every allocation has exactly one owner at a
+time, moving a value transfers that ownership, and the borrow checker forbids
+aliasing that could outlive or conflict with the owner. Safety follows from the
+rule that there is only ever one path responsible for freeing a value.
+
+CLR instead tracks *provenance*: it follows where a value came from and what
+allocation it ultimately refers to, and attaches safety state information to that 
+underlying allocation. Multiple values or paths may legitimately refer to the same
+allocation. Safety follows from the state of the allocation itself: once any path
+frees it, the allocation is considered freed everywhere, and subsequent use or a
+second free through any alias is reported.
+
+The practical consequences of choosing provenance over ownership:
+
+- CLR does not reject aliasing or shared references the way a borrow checker
+  does; several bindings pointing at one allocation is normal and analyzable.
+- CLR does not model move semantics. Nothing is "consumed" by being passed or
+  assigned; the allocation simply retains its safety state.
+- Because there is no single owner, CLR reasons about the allocation's lifecycle
+  (allocated → used → freed) rather than about who is permitted to free it.
+
+In the CLR model, aliasing *safety*, proving that concurrent or overlapping 
+aliases do not violate each other's assumptions, is a separate concern from 
+allocation lifecycle safety and is not modeled yet, though it is planned.
+
+### Interprocedural Allocation Safety
+
+CLR analyzes across function calls by triggering an analysis pass of the callee
+as part of analyzing the caller: arguments are passed in with their current
+provenance, the callee's body is analyzed against the same shared state, and both
+the returned value's provenance and any mutations made through pointer arguments
+flow back to the caller. This lets CLR follow an allocation created in one
+function and freed in another, or returned to its caller, without special
+annotations.  Notably, it does not build the machinery a classical whole-program 
+analyzer would use, such as per-function summaries, a computed call-graph ordering, 
+or context-sensitive value tracking across many call sites.
+
+### Global Allocation Leak Detection
+
+Allocations reachable from globals are exempt from normal leak detection outside
+the entrypoint. At the entrypoint, CLR also checks allocations stored through
+global entities before program exit.
+
+This avoids false positives for intentionally program-lifetime allocations inside
+library-style functions, but it also means memory allocated into a global from a
+non-entrypoint function and never freed may not be reported there as a leak.
+
+## Deliberate Non-Goals Or Coarse Models
+
 ### Custom Allocator Protocols
 
 CLR recognizes standard `std.mem.Allocator`-style allocation operations. Custom
-allocator protocols that do not follow those patterns are not generally tracked.
-For example, if you do raw calls to C's `malloc`/`free` these memory will not be
-tracked.
-
-## Deliberate Non-Goals Or Coarse Models
+allocator protocols that do not follow those patterns are not tracked. For
+example, raw calls to C's `malloc`/`free` are not tracked, and memory obtained
+directly from the operating system via syscalls (for example `mmap`ing a page, or
+otherwise asking the OS for memory) is not tracked either. Idiomatic Zig routes
+allocation through the `std.mem.Allocator` interface, and CLR intentionally only
+follows memory that flows through it.
 
 ### Per-Element Region Tracking
 
@@ -358,6 +267,46 @@ CLR does not perform array, slice, or pointer bounds checking. Zig's runtime
 safety checks and the compiler's own semantics cover some of this space, but CLR
 does not model it independently.
 
+### Manual Null-Check Narrowing
+
+CLR narrows optional null-safety only through the structural forms Zig generates —
+`if (opt) |x|` capture and the `.?` unwrap (`is_non_null` guard plus
+`optional_payload`). It deliberately does not recognize hand-written guards that
+prove non-nullness some other way, such as `if (opt != null) { use opt.? } else
+@panic()`. These patterns can produce a conservative unchecked-unwrap result. Use
+the idiomatic capture/`.?` forms, or an eventual declaration, to express the
+invariant instead.
+
+### Derived Pointers And Pointer Arithmetic
+
+Derived pointers — those produced by `ptr_add`/`ptr_sub`, slice extraction, or
+field access — are deliberately treated as unsafe to free. They carry a
+`root_gid` back to their parent allocation, and free/destroy through a derived
+pointer is rejected by design; CLR does not attempt to prove that arithmetic has
+returned a pointer to its allocation base. This is a choice, not a missing
+feature: an explicit retag mechanism (or a narrow internal stdlib override) could
+re-establish base-allocation provenance in the future, but absent that, derived
+frees stay illegal.
+
+Pointer arithmetic must operate on a pointer-to-region; non-pointer and
+single-item pointer inputs fail loudly with a clear analysis error. CLR does not
+perform pointer arithmetic bounds checking and does not prove that a derived
+pointer remains within its region.
+
+### Alignment-Cast Lowering
+
+`@ptrCast(@alignCast(...))` lowers into AIR that bitcasts a pointer to an
+address-like scalar, masks low bits, and branches on the alignment check. Current
+analyses can misinterpret that sequence as ordinary pointer/int dataflow.
+
+CLR deliberately does not model this. The compiler already prevents almost every
+way an alignment-cast error could actually occur, and tracking the guard properly
+would require carrying pointer provenance through integer values — a
+types-through-pointers model, potentially with modular tagging of integers — that
+CLR intentionally does not implement (see the "Inst Type Tracking" non-goal in
+`CLAUDE.md`). The residual risk is narrow enough to leave unmodeled rather than
+build that machinery.
+
 ### Integer Overflow
 
 Potential integer overflow in arithmetic operations is not detected.
@@ -369,9 +318,9 @@ currently assumes single-threaded execution for analysis purposes.
 
 ### Const-Correctness
 
-General const-correctness is handled by Zig. CLR may still need to be careful
-that `@constCast` does not erase safety-relevant dataflow, but it is not a
-separate const checker.
+General const-correctness is handled by Zig. CLR may still (unlikely) need to be 
+careful that `@constCast` does not erase safety-relevant dataflow, but it does not 
+have a const checker.
 
 ### Error Value Propagation
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -25,11 +25,13 @@ the future.
 
 Managed `std.HashMap` values are represented by a privileged refinement with
 canonical metadata, key, and value storage GIDs. The supported opaque boundary
-currently covers `init`, `put`, `get`, `getPtr`, `valueIterator`,
-`FieldIterator.next`, and `deinit`; selected unmanaged metadata helpers remain
-narrow overrides. This avoids depending on HashMap's private struct layout and
-does not weaken general optional unwrap, pointer arithmetic, packed metadata,
-or leak checking.
+currently covers `init`, `put`, `get`, `getPtr`, `contains`, `iterator`,
+`Iterator.next`, `valueIterator`, `FieldIterator.next`, `keys`/`values`,
+`getIndex`, `deinit`, and `deallocate`; selected unmanaged metadata helpers
+(fill/remove mutators, `isUsed`/`isFree`/`isTombstone` predicates, and the
+assume-capacity storage mutators) remain narrow overrides. This avoids depending
+on HashMap's private struct layout and does not weaken general optional unwrap,
+pointer arithmetic, packed metadata, or leak checking.
 
 The current model has one representative key slot and one representative value
 slot per map, not per-entry storage. It covers scalar maps and the tested case
@@ -115,6 +117,11 @@ Returning pointers inside structs, unions, or globals is still conservative in
 some cases. Basic fieldParentPtr recovery for structs, unions, and global
 struct/union fields is covered, but returned pointers through aggregate values
 and merged pointers can still lose enough provenance to produce false positives.
+
+Early error returns are handled: when a function takes an error path before its
+success payload is constructed, the interned error union's structural payload is
+marked an inactive error stub, so branch merging does not misreport the
+not-yet-allocated success payload (for example a slice field) as a leak.
 
 This area overlaps with stack lifetime tracking: CLR detects some escaping stack
 pointers, but it does not yet have a complete tombstone model for stack memory

--- a/lib/analysis/memory_safety.zig
+++ b/lib/analysis/memory_safety.zig
@@ -1152,6 +1152,12 @@ pub const MemorySafety = union(enum) {
         }
     }
 
+    pub fn init_error_return(refinements: *Refinements, gid: Gid) void {
+        const ref = refinements.at(gid);
+        if (ref.* != .errorunion) @panic("error return slot is not an error union");
+        markPayloadErrorStub(refinements, ref.errorunion.to);
+    }
+
     /// Called on function close to check for memory leaks and stack pointer escapes.
     /// With global refinements, args share entities directly with caller.
     /// Stack pointer escapes through args are detected by checking arg pointees.
@@ -2253,6 +2259,7 @@ pub const MemorySafety = union(enum) {
             fn first(orig: Gid, branches_: []const ?State, branch_gids_: []const ?Gid) ?MemorySafety {
                 _ = orig;
                 var fallback: ?MemorySafety = null;
+                var error_fallback: ?MemorySafety = null;
                 for (branches_, branch_gids_) |branch_opt, branch_gid_opt| {
                     const branch = branch_opt orelse continue;
                     const branch_gid = branch_gid_opt orelse continue;
@@ -2263,9 +2270,13 @@ pub const MemorySafety = union(enum) {
                     };
                     const ms = branch_analyte.memory_safety orelse continue;
                     if (ms == .allocated) return ms;
+                    if (merge_tag == .early_return and ms == .error_stub) {
+                        if (error_fallback == null) error_fallback = ms;
+                        continue;
+                    }
                     if (fallback == null) fallback = ms;
                 }
-                return fallback;
+                return fallback orelse error_fallback;
             }
         };
 

--- a/lib/analysis/memory_safety_test.zig
+++ b/lib/analysis/memory_safety_test.zig
@@ -967,6 +967,127 @@ test "allocation returned through block break is not reported as callee leak" {
     try Inst.onFinish(state);
 }
 
+test "early error return does not overwrite successful struct pointer payload with interned state" {
+    var ctx, var refinements = initTest();
+    defer ctx.deinit();
+    defer refinements.deinit();
+
+    const allocator_gid = try refinements.appendEntity(.{ .allocator = .{
+        .type_id = 100,
+        .analyte = .{ .memory_safety = .{ .stack = .{ .trace = ctx.captureTrace(), .root_gid = null } } },
+    } });
+    const item_type: tag.Type = .{ .@"struct" = &.{
+        .type_id = 101,
+        .fields = &.{.{ .scalar = .{} }},
+    } };
+    const slice_type: tag.Type = .{ .pointer = .{
+        .to = &.{ .pointer = .{
+            .to = &item_type,
+            .multiplicity = .region,
+        } },
+    } };
+    const payload_type: tag.Type = .{ .@"struct" = &.{
+        .type_id = 102,
+        .fields = &.{ .{ .allocator = .{ .type_id = 100 } }, slice_type, .{ .scalar = .{} } },
+    } };
+    const return_type: tag.Type = .{ .errorunion = .{ .to = &payload_type } };
+    const return_gid = try refinements.appendEntity(try tag.typeToRefinement(return_type, &refinements));
+    tag.splatInitCallReturnSlot(&refinements, return_gid, &ctx);
+
+    const success_gid = try refinements.appendEntity(try tag.typeToRefinement(return_type, &refinements));
+    tag.splatInitCallReturnSlot(&refinements, success_gid, &ctx);
+    const success_payload_gid = refinements.at(success_gid).errorunion.to;
+    const success_payload = refinements.at(success_payload_gid).@"struct";
+    const success_slice_gid = success_payload.fields[1];
+    const success_slice = &refinements.at(success_slice_gid).pointer;
+    success_slice.analyte.memory_safety = .{ .stack = .{ .trace = ctx.captureTrace(), .root_gid = null } };
+    refinements.at(success_slice.to).pointer.analyte.memory_safety = .{ .allocated = .{
+        .trace = ctx.captureTrace(),
+        .root_gid = null,
+        .allocator_gid = allocator_gid,
+        .type_id = 100,
+    } };
+
+    var results = [_]Inst{.{}} ** 3;
+    results[0].refinement = success_gid;
+    var early_returns = std.ArrayListUnmanaged(State){};
+    defer Inst.freeEarlyReturns(&early_returns, ctx.allocator);
+    const state = State{
+        .ctx = &ctx,
+        .results = &results,
+        .refinements = &refinements,
+        .return_gid = return_gid,
+        .base_gid = success_gid,
+        .early_returns = &early_returns,
+        .restrict = .memory_safety,
+    };
+
+    try Inst.apply(state, 1, .{ .ret_safe = .{
+        .src = .{ .interned = .{ .ip_idx = 999, .ty = return_type } },
+        .is_error = true,
+    } });
+    try Inst.apply(state, 2, .{ .ret_safe = .{ .src = .{ .inst = 0 } } });
+    try Inst.mergeEarlyReturns(state);
+
+    const merged_payload = refinements.at(refinements.at(return_gid).errorunion.to).@"struct";
+    const merged_slice = refinements.at(merged_payload.fields[1]).pointer;
+    try std.testing.expectEqual(.stack, std.meta.activeTag(merged_slice.analyte.memory_safety.?));
+    try std.testing.expectEqual(.allocated, std.meta.activeTag(
+        refinements.at(merged_slice.to).pointer.analyte.memory_safety.?,
+    ));
+}
+
+test "error return preserves allocated return slot and marks payload inactive" {
+    var ctx, var refinements = initTest();
+    defer ctx.deinit();
+    defer refinements.deinit();
+
+    const allocator_gid = try refinements.appendEntity(.{ .allocator = .{
+        .type_id = 100,
+        .analyte = .{ .memory_safety = .{ .stack = .{ .trace = ctx.captureTrace(), .root_gid = null } } },
+    } });
+    const payload_type: tag.Type = .{ .@"struct" = &.{
+        .type_id = 101,
+        .fields = &.{.{ .pointer = .{ .to = &.{ .scalar = .{} } } }},
+    } };
+    const return_type: tag.Type = .{ .errorunion = .{ .to = &payload_type } };
+    const return_gid = try refinements.appendEntity(try tag.typeToRefinement(return_type, &refinements));
+    tag.splatInitCallReturnSlot(&refinements, return_gid, &ctx);
+    refinements.at(return_gid).errorunion.analyte.memory_safety = .{ .allocated = .{
+        .trace = ctx.captureTrace(),
+        .root_gid = return_gid,
+        .allocator_gid = allocator_gid,
+        .type_id = 100,
+    } };
+
+    var results = [_]Inst{.{}};
+    var early_returns = std.ArrayListUnmanaged(State){};
+    defer Inst.freeEarlyReturns(&early_returns, ctx.allocator);
+    const state = State{
+        .ctx = &ctx,
+        .results = &results,
+        .refinements = &refinements,
+        .return_gid = return_gid,
+        .base_gid = @intCast(refinements.list.items.len),
+        .early_returns = &early_returns,
+        .restrict = .memory_safety,
+    };
+
+    try Inst.apply(state, 0, .{ .ret_safe = .{
+        .src = .{ .interned = .{ .ip_idx = 999, .ty = return_type } },
+        .is_error = true,
+    } });
+
+    const returned = early_returns.items[0].refinements;
+    try std.testing.expectEqual(.allocated, std.meta.activeTag(
+        returned.at(return_gid).errorunion.analyte.memory_safety.?,
+    ));
+    const payload_gid = returned.at(return_gid).errorunion.to;
+    try std.testing.expectEqual(.error_stub, std.meta.activeTag(
+        returned.at(payload_gid).@"struct".analyte.memory_safety.?,
+    ));
+}
+
 test "local pointer slot containing argument allocation is not reported as callee leak" {
     var ctx, var refinements = initTest();
     defer ctx.deinit();

--- a/lib/tag.zig
+++ b/lib/tag.zig
@@ -1018,6 +1018,9 @@ pub const UnwrapErrunionPayloadPtr = struct {
 pub const RetSafe = struct {
     /// Value being returned. Use .interned with .void for void returns.
     src: Src,
+    /// True when an interned error union contains the error variant, so its
+    /// structural payload is inactive rather than an interned value.
+    is_error: bool = false,
 
     pub fn apply(self: @This(), state: State, index: usize) !void {
         const allocator = state.ctx.allocator;
@@ -1049,6 +1052,9 @@ pub const RetSafe = struct {
                 try Refinement.copyToSlot(return_gid, state.refinements.at(src_gid).*, state.refinements, cloned);
             },
             .interned => |interned| {
+                if (self.is_error) {
+                    splatInitErrorReturn(cloned, return_gid);
+                } else
                 // Try to look up as tracked global first
                 if (cloned.getGlobal(interned.ip_idx)) |global_gid| {
                     // Return an interned variable by overwriting the cloned return slot
@@ -2707,6 +2713,14 @@ pub fn splatFinish(results: []Inst, ctx: *Context, refinements: *Refinements, re
 pub fn splatInitInterned(refinements: *Refinements, gid: Gid) void {
     // Interned values are always defined - use the unified init (no ctx needed)
     splatInit(refinements, gid, null, .defined);
+}
+
+fn splatInitErrorReturn(refinements: *Refinements, gid: Gid) void {
+    inline for (Analyte.analyses) |Analysis| {
+        if (@hasDecl(Analysis, "init_error_return")) {
+            Analysis.init_error_return(refinements, gid);
+        }
+    }
 }
 
 /// Called after receiving a return value from a function call.

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -545,6 +545,13 @@ fn isZeroRef(info: *const FnInfo, ref: Ref) bool {
 /// Payload for ret_safe - just the src, caller_refinements and return_gid come from State.
 fn payloadRetSafe(info: *const FnInfo, datum: Data) []const u8 {
     const src_str = srcString(info, datum.un_op);
+    const is_error = if (datum.un_op.toInterned()) |interned_idx| blk: {
+        const key = info.ip.indexToKey(interned_idx);
+        break :blk key == .error_union and key.error_union.val == .err_name;
+    } else false;
+    if (is_error) {
+        return clr_allocator.allocPrint(info.arena, ".{{ .src = {s}, .is_error = true }}", .{src_str}, null);
+    }
     return clr_allocator.allocPrint(info.arena, ".{{ .src = {s} }}", .{src_str}, null);
 }
 

--- a/test/cases/allocator_safety/error_paths/early_error_struct_slice_free.zig
+++ b/test/cases/allocator_safety/error_paths/early_error_struct_slice_free.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+const Item = struct {
+    value: usize,
+};
+
+const Buffer = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    items: []*Item,
+    head: usize = 0,
+    tail: usize = 0,
+    len: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator, len: usize) !Buffer {
+        if (len == 0) return error.InvalidLength;
+
+        return Self{
+            .allocator = allocator,
+            .items = try allocator.alloc(*Item, len),
+        };
+    }
+
+    fn deinit(self: *Buffer) void {
+        self.allocator.free(self.items);
+        self.* = undefined;
+    }
+};
+
+pub fn main() !void {
+    var map = std.AutoHashMap(usize, Buffer).init(std.heap.page_allocator);
+    defer map.deinit();
+
+    try map.put(1, try Buffer.init(std.heap.page_allocator, 1));
+
+    var iterator = map.iterator();
+    while (iterator.next()) |entry| {
+        entry.value_ptr.deinit();
+        break;
+    }
+}

--- a/test/integration/misc.bats
+++ b/test/integration/misc.bats
@@ -78,6 +78,11 @@ load test_helper
     [ "$status" -eq 0 ]
 }
 
+@test "early error return preserves allocated slice in struct success payload" {
+    run compile_and_run "$TEST_CASES/allocator_safety/error_paths/early_error_struct_slice_free.zig"
+    [ "$status" -eq 0 ]
+}
+
 @test "no false positive for error path clearing allocation metadata" {
     # When an allocation fails (error path), phantom allocation metadata must be
     # cleared while maintaining valid refinement state (memory_safety set to .unset).


### PR DESCRIPTION
Audits `LIMITATIONS.md` and `CLAUDE.md` against the actual analyzer code, correcting stale/incorrect claims and reorganizing the limitations doc into clear categories. Also includes one code fix uncovered along the way.

## Commits

- **Preserve allocated payload across early error returns** — when a function takes an error path before its success payload is constructed, the interned error union's structural payload is marked an inactive error stub so branch merging does not misreport the not-yet-allocated payload as a leak. Includes unit + integration tests.
- **Sync CLAUDE.md with current analyzer code** — corrected `state: State` handler/splat signatures, `_instLine` signature, added `fd_safety` to the analyte list, removed resolved items (BinOp/UnOp, dbg_inline_block, ret_load/ret_ptr), fixed the "set a pointer to undefined" notes.
- **Restructure LIMITATIONS.md around verified analyzer behavior** — every claim checked against `lib/`/`src/`.

## LIMITATIONS.md restructure

Reorganized into: informational **stdlib overrides**, **current active gaps** (planned), the **memory-safety / provenance model**, and **deliberate non-goals**.

Removed stale or incorrect entries (verified against code):
- FD alias/closure "gap" — aliasing works via shared `FdRef`; math on a tracked fd is a hard error, so there was no silent-loss gap.
- Stack escape / returned aggregate provenance — recursive escape checks + test coverage exist; the "tombstone model" was never-started prose.
- Cross-function global mutation — callees analyze against the shared refinements table, so global mutations are visible to callers.
- Global pointer values — pointer-valued globals are resolved from the InternPool and keep their global-memory fact through indirection.
- Global union initial values — active-variant import is implemented and tested end-to-end.
- Codegen type-extraction gaps — allocator-create payload and slice element type extraction are implemented; only the `.recursive` placeholder remains partial.

Reframed as deliberate non-goals: derived-pointer frees (`root_gid` enforces by design), alignment-cast lowering (would need types-through-pointers tracking we won't do), manual null-check-then-panic patterns, and custom / syscall allocation protocols.

Rewrote the ownership-vs-provenance and interprocedural entries in a conceptual, no-internals voice. Added active gaps reflecting real work: custodial relationships (HashMap multi-entry ownership), allocator-wide deinit invalidation, `intcast`, interned-source pointer transforms, the `.recursive` placeholder, and a "flagging unsafe code" surfacing mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)